### PR TITLE
Skip internal topic mirroring

### DIFF
--- a/backup/mm2.yaml
+++ b/backup/mm2.yaml
@@ -99,6 +99,7 @@ spec:
         # Interval period to refresh consumer groups statuses (Default: 600)
         refresh.groups.interval.seconds: 60
         #offset-syncs.topic.location: target # In case you want all mm2 internal topic in the target cluster. The mm2-offset-sync topic is created in the source cluster by default.
+    topicsExcludePattern: '.*\.internal, mirrormaker2.*, __.*'
     topicsPattern: ".*"
     groupsPattern: ".*"
   logging:

--- a/backup/reader-user.yaml
+++ b/backup/reader-user.yaml
@@ -29,7 +29,6 @@ spec:
         host: "*"
       - resource:
           type: cluster
-          patternType: literal
         operations:
           - Describe
         host: "*"

--- a/primary/target-mirroring-user.yaml
+++ b/primary/target-mirroring-user.yaml
@@ -31,7 +31,6 @@ spec:
         host: "*"
       - resource:
           type: cluster
-          patternType: literal
         operations:
           - Describe
         host: "*"


### PR DESCRIPTION
Configured `topicsExcludePattern` to avoid mirroring for internal topics.